### PR TITLE
Fix startup crash by readding `android:key`s to root_preferences.xml

### DIFF
--- a/app/src/main/res/xml/root_preferences.xml
+++ b/app/src/main/res/xml/root_preferences.xml
@@ -1,6 +1,6 @@
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
 
-    <PreferenceCategory android:title="@string/settings_header">
+    <PreferenceCategory android:title="@string/settings_header" android:key="settings">
         <SwitchPreference
             android:key="enable"
             android:title="@string/enable_title" />
@@ -19,7 +19,7 @@
 
     </PreferenceCategory>
 
-    <PreferenceCategory android:title="@string/status_header">
+    <PreferenceCategory android:title="@string/status_header" android:key="status">
 
         <Preference
             android:key="request_brightness"


### PR DESCRIPTION
I think they were removed accidentally in https://github.com/dantmnf/PseudoDCDimming/commit/8de6c9b1e69d36293842980bce450644e0b31bcf. Readding them back using apktool fixed the startup crash observed on Pixel 6 Pro and OnePlus 8 Pro, Android 14 and 13.