### PR TITLE
忽略外接显示器

### DIFF
--- a/app/src/main/java/xyz/cirno/pseudodcdimming/xposed/BacklightOverrideService.java
+++ b/app/src/main/java/xyz/cirno/pseudodcdimming/xposed/BacklightOverrideService.java
@@ -224,8 +224,14 @@ public class BacklightOverrideService {
             if (request.backlightLevel < minOverrideBacklight) {
                 overrideBacklight = minOverrideBacklight;
                 overrideNits = minOverrideNits;
-                gain = (request.backlightNits / minOverrideNits);
-                gain = Math.max(gain, deviceMinimumBacklightNits / minOverrideNits);
+                if (isValidNits(request.backlightNits) && isValidNits(minOverrideNits)) {
+                    gain = (request.backlightNits / minOverrideNits);
+                    if (isValidNits(deviceMinimumBacklightNits)) {
+                        gain = Math.max(gain, deviceMinimumBacklightNits / minOverrideNits);
+                    }
+                } else if (minOverrideBacklight > 0.0f) {
+                    gain = request.backlightLevel / minOverrideBacklight;
+                }
                 //gain = Math.max(gain, overrideService.minimumGain);
                 //gain = Math.max(gain, 0.05f);
             }
@@ -245,6 +251,10 @@ public class BacklightOverrideService {
         var result = new BacklightOverrideState(override, gain, pref);
         setLastBacklightOverride(result);
         return result;
+    }
+
+    private static boolean isValidNits(float value) {
+        return Float.isFinite(value) && value > 0.0f;
     }
 
     public void setTransformGain(float gain) {

--- a/app/src/main/java/xyz/cirno/pseudodcdimming/xposed/XposedInit.java
+++ b/app/src/main/java/xyz/cirno/pseudodcdimming/xposed/XposedInit.java
@@ -94,6 +94,8 @@ public class XposedInit implements IXposedHookLoadPackage {
                     if (param.hasThrowable()) {
                         return;
                     }
+                    // param.args[3] = StaticDisplayInfo, param.args[6] = isDefaultDisplay
+                    if (!isInternalDisplay(param.args[3], (boolean)param.args[6])) return;
                     final var displayDeviceConfig = new DisplayDeviceConfigProxy(XposedHelpers.callMethod(param.thisObject,"getDisplayDeviceConfig"));
                     overrideService.lateInitialize(displayDeviceConfig);
                 }
@@ -224,5 +226,14 @@ public class XposedInit implements IXposedHookLoadPackage {
                     }
                 }
             });
+    }
+
+    private static boolean isInternalDisplay(Object staticInfo, boolean isDefaultDisplay) {
+        if (staticInfo == null) return isDefaultDisplay;
+        try {
+            return XposedHelpers.getBooleanField(staticInfo, "isInternal");
+        } catch (Throwable t) {
+            return isDefaultDisplay;
+        }
     }
 }


### PR DESCRIPTION
经常用显示屏带的PD线给手机充电，但发现插上之后这个模块就失效了

LLM 给的判断：

- 外接屏后初始化时覆盖内置屏 config，外接屏 nits 为 -1，导致 minOverrideNits=-1，后续 gain 可能算成 1。
- 非内置屏应忽略，不应污染内置屏配置。

同时加了一个防御性的 nit 是否正确，导致屏幕会一直最亮

LLM 查询： isInternal：AOSP Android 12 / SDK 31 已有，兼容性没有问题